### PR TITLE
feat: Add /stiven route with current date

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 
 
 def hello(event, context):
@@ -9,6 +10,15 @@ def hello(event, context):
 
     response = {"statusCode": 200, "body": json.dumps(body)}
 
+    return response
+
+def hello_stiven(event, context):
+    current_date = datetime.date.today().strftime("%Y-%m-%d")
+    message = f"Hola Stiven {current_date}"
+    body = {
+        "message": message
+    }
+    response = {"statusCode": 200, "body": json.dumps(body)}
     return response
 
 def saludo(event, context):

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,3 +22,10 @@ functions:
       - http:
           path: /saludo
           method: get
+
+  hello_stiven:
+    handler: handler.hello_stiven
+    events:
+      - http:
+          path: /stiven
+          method: get

--- a/test_handler.py
+++ b/test_handler.py
@@ -1,0 +1,16 @@
+import json
+import datetime
+import handler
+
+def test_hello_stiven():
+    response = handler.hello_stiven({}, {})
+    assert response['statusCode'] == 200
+    
+    parsed_body = json.loads(response['body'])
+    assert parsed_body['message'].startswith("Hola Stiven ")
+    
+    date_string = parsed_body['message'].replace("Hola Stiven ", "")
+    try:
+        datetime.datetime.strptime(date_string, '%Y-%m-%d')
+    except ValueError:
+        assert False, f"Date string '{date_string}' is not in YYYY-MM-DD format"


### PR DESCRIPTION
I added a new route `/stiven` that responds to GET requests.

The route is handled by the `hello_stiven` function in `handler.py`. This function returns a JSON response with the message "Hola Stiven <current_date>", where `<current_date>` is the current date in YYYY-MM-DD format.

The `serverless.yml` file has been updated to map the `/stiven` path to the new handler function.

A new test file `test_handler.py` was created with a test case `test_hello_stiven` that verifies:
- The status code is 200.
- The message starts with "Hola Stiven ".
- The date in the message is correctly formatted.